### PR TITLE
Aumenta escopo do catch do isClass

### DIFF
--- a/src/Controllers/ResourceController.php
+++ b/src/Controllers/ResourceController.php
@@ -753,7 +753,7 @@ class ResourceController extends Controller
 	{
 		try {
 			return class_exists(get_class(@$target->{$index}));
-		} catch (\Exception $e) {
+		} catch (\Throwable $e) {
 			return false;
 		}
 	}


### PR DESCRIPTION
Nem todas as vezes o que vai ser recebido será um objeto, então o catch do ResourceController->isClass, não vai pegar FatalThrowables do Symfony, causando o seguinte erro

```json
{
    "exception": "Symfony\\Component\\Debug\\Exception\\FatalThrowableError",
    "file": ".\\vendor\\marcusvbda\\vstack\\src\\Controllers\\ResourceController.php",
    "line": 755,
    "message": "get_class(): Argument #1 ($object) must be of type object, null given"
}
```